### PR TITLE
Add registration_id condition before generate new certificate

### DIFF
--- a/docker/resources/start.sh
+++ b/docker/resources/start.sh
@@ -245,7 +245,8 @@ customize_runtime()
         CFTUTIL /m=2 uconfset id='copilot.restapi.enable', value='YES'
 
         copilot_cert=$(cftuconf copilot.ssl.SslCertFile)
-        if [ -z "$copilot_cert" ]; then
+        registration_id=$(cftuconf cg.registration_id)
+        if [ -z "$copilot_cert" ] && [ "$registration_id" = "-1" ]; then
             # CREATE CERTIFICATES FOR REST API
             generate_certificate
 


### PR DESCRIPTION
Currently if you recreate a CFT (with runtime volume) CFT will regenerate and replace in CFT conf default certificate
This is not neccesary because CFT got already FM certificate

Saw on a project when we manually register FM to CFT and restart CFT